### PR TITLE
Fix marshal_test.go import

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	eventsapi "github.com/containerd/containerd/api/services/events/v1"
-	"github.com/containerd/containerd/typeurl"
+	eventsapi "github.com/containerd/containerd/api/events"
+	"github.com/containerd/typeurl"
 )
 
 func TestMarshalEvent(t *testing.T) {


### PR DESCRIPTION
Go get fails, apparently due to a mistake in the import path in `marshal_test.go`.

    # go get -t -u github.com/containerd/typeurl
    package github.com/containerd/containerd/typeurl: cannot find package "github.com/containerd/containerd/typeurl" in any of:
	/usr/lib/go-1.7/src/github.com/containerd/containerd/typeurl (from $GOROOT)
	/usr/src/golang/src/github.com/containerd/containerd/typeurl (from $GOPATH)
