### PR TITLE
typeurl: make marshal_test.go compile again and then pass

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	eventsapi "github.com/containerd/containerd/api/services/events/v1"
-	"github.com/containerd/containerd/typeurl"
+	eventsapi "github.com/containerd/containerd/api/events"
+	"github.com/containerd/typeurl"
 )
 
 func TestMarshalEvent(t *testing.T) {
@@ -16,12 +16,12 @@ func TestMarshalEvent(t *testing.T) {
 	}{
 		{
 			event: &eventsapi.TaskStart{},
-			url:   "types.containerd.io/containerd.services.events.v1.TaskStart",
+			url:   "containerd.events.TaskStart",
 		},
 
 		{
 			event: &eventsapi.NamespaceUpdate{},
-			url:   "types.containerd.io/containerd.services.events.v1.NamespaceUpdate",
+			url:   "containerd.events.NamespaceUpdate",
 		},
 	} {
 		t.Run(fmt.Sprintf("%T", testcase.event), func(t *testing.T) {


### PR DESCRIPTION
The test was importing the old import path instead of the new
import path, so it wasn't testing the code in this directory.
(And the code it was trying to test no longer exists.)

After making the test build, change the expected type
identifiers (per f694355) to make it also pass.