### PR TITLE
Add more documentation to Register.

### DIFF
--- a/types.go
+++ b/types.go
@@ -34,7 +34,10 @@ var (
 
 var ErrNotFound = errors.New("not found")
 
-// Register a type with the base url of the type
+// Register a type with a base URL for JSON marshaling. When the MarshalAny and
+// UnmarshalAny functions are called they will treat the Any type value as JSON.
+// To use protocol buffers for handling the Any value the proto.Register
+// function should be used instead of this function.
 func Register(v interface{}, args ...string) {
 	var (
 		t = tryDereference(v)
@@ -51,7 +54,7 @@ func Register(v interface{}, args ...string) {
 	registry[t] = p
 }
 
-// TypeURL returns the type url for a registred type
+// TypeURL returns the type url for a registred type.
 func TypeURL(v interface{}) (string, error) {
 	mu.Lock()
 	u, ok := registry[tryDereference(v)]
@@ -67,7 +70,7 @@ func TypeURL(v interface{}) (string, error) {
 	return u, nil
 }
 
-// Is returns true if the type of the Any is the same as v
+// Is returns true if the type of the Any is the same as v.
 func Is(any *types.Any, v interface{}) bool {
 	// call to check that v is a pointer
 	tryDereference(v)
@@ -111,7 +114,7 @@ func MarshalAny(v interface{}) (*types.Any, error) {
 	}, nil
 }
 
-// UnmarshalAny unmarshals the any type into a concrete type
+// UnmarshalAny unmarshals the any type into a concrete type.
 func UnmarshalAny(any *types.Any) (interface{}, error) {
 	t, err := getTypeByUrl(any.TypeUrl)
 	if err != nil {


### PR DESCRIPTION
This adds documentation about how using the Register function causes the Any
value to be treated as JSON. I'd found this confusing when new to the package.

Also, add a few periods to function docs to make things consistent.