### PR TITLE
Add unmarshal to out interface

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -101,6 +101,56 @@ func TestMarshalUnmarshal(t *testing.T) {
 	}
 }
 
+func TestMarshalUnmarshalTo(t *testing.T) {
+	clear()
+	Register(&test{}, "test")
+
+	in := &test{
+		Name: "koye",
+		Age:  6,
+	}
+	any, err := MarshalAny(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := &test{}
+	err = UnmarshalTo(any, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Name != "koye" {
+		t.Fatal("invalid name")
+	}
+	if out.Age != 6 {
+		t.Fatal("invalid age")
+	}
+}
+
+type test2 struct {
+	Name string
+}
+
+func TestUnmarshalToInvalid(t *testing.T) {
+	clear()
+	Register(&test{}, "test1")
+	Register(&test2{}, "test2")
+
+	in := &test{
+		Name: "koye",
+		Age:  6,
+	}
+	any, err := MarshalAny(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := &test2{}
+	err = UnmarshalTo(any, out)
+	if err == nil || err.Error() != `can't unmarshal type "test1" to output "test2"` {
+		t.Fatalf("unexpected result: %+v", err)
+	}
+}
+
 func TestIs(t *testing.T) {
 	clear()
 	Register(&test{}, "test")


### PR DESCRIPTION
In current implementation every `UnmarshalAny` requires 2 `if` statements - the first one is to unmarshal any and check for errors, and second one to cast returned interface to a concrete type. 

```go
	nv, err := UnmarshalAny(any)
	if err != nil {
		t.Fatal(err)
	}
	td, ok := nv.(*test)
	if !ok {
		t.Fatal("expected value to cast to *test")
	}
```

This PR adds `UnmarshalTo` which lets clients to provide a destination type from outside, and hence have just one `if`, similarly to `json.Unmarshal` or `proto.Unmarshal`.

```go
	out := &test{}
	err = UnmarshalTo(any, out)
	if err != nil {
		t.Fatal(err)
	}
```

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>