### PR TITLE
Add Any type and remove gogo protobuf from interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Go package for managing the registration, marshaling, and unmarshaling of encoded types.
 
-This package helps when types are sent over a GRPC API and marshaled as a [protobuf.Any](https://github.com/gogo/protobuf/blob/master/protobuf/google/protobuf/any.proto).
+This package helps when types are sent over a ttrpc/GRPC API and marshaled as a protobuf [Any](https://pkg.go.dev/google.golang.org/protobuf@v1.27.1/types/known/anypb#Any)
 
 ## Project details
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/containerd/typeurl
 
 go 1.13
 
-require github.com/gogo/protobuf v1.3.2
+require (
+	github.com/gogo/protobuf v1.3.2
+	google.golang.org/protobuf v1.27.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -28,4 +31,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -45,8 +45,8 @@ func TestMarshalEvent(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if a.TypeUrl != testcase.url {
-				t.Fatalf("unexpected url: %q != %q", a.TypeUrl, testcase.url)
+			if a.TypeURL != testcase.url {
+				t.Fatalf("unexpected url: %q != %q", a.TypeURL, testcase.url)
 			}
 
 			v, err := UnmarshalAny(a)
@@ -71,7 +71,7 @@ func BenchmarkMarshalEvent(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		if a.TypeUrl != expected.TypeUrl {
+		if a.TypeURL != expected.TypeURL {
 			b.Fatalf("incorrect type url: %v != %v", a, expected)
 		}
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -17,6 +17,7 @@
 package typeurl
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 )
@@ -57,8 +58,8 @@ func TestMarshal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if any.TypeUrl != expected {
-		t.Fatalf("expected %q but received %q", expected, any.TypeUrl)
+	if any.TypeURL != expected {
+		t.Fatalf("expected %q but received %q", expected, any.TypeURL)
 	}
 
 	// marshal it again and make sure we get the same thing back.
@@ -67,7 +68,10 @@ func TestMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if newany != any { // you that right: we want the same *pointer*!
+	// Ensure pointer to same exact slice
+	newany.Value[0] = any.Value[0] ^ 0xff
+
+	if !bytes.Equal(newany.Value, any.Value) {
 		t.Fatalf("expected to get back same object: %v != %v", newany, any)
 	}
 


### PR DESCRIPTION
Add a new Any type which can be used with gogo or google protobuf libraries. Support marshaling and unmarshaling with either library.

This is needed to help us move away from gogo protobuf and to break out reliance on external types in our interface (`*types.Any` -> `typeurl.Any`).

With this change, will probably make sense to tag as v2.0 and tag the current version as v1.0.3