### PR TITLE
Make nil handling easier

### DIFF
--- a/types.go
+++ b/types.go
@@ -55,11 +55,17 @@ type any struct {
 	value   []byte
 }
 
-func (a any) GetTypeUrl() string {
+func (a *any) GetTypeUrl() string {
+	if a == nil {
+		return ""
+	}
 	return a.typeURL
 }
 
-func (a any) GetValue() []byte {
+func (a *any) GetValue() []byte {
+	if a == nil {
+		return nil
+	}
 	return a.value
 }
 
@@ -136,14 +142,14 @@ func MarshalAny(v interface{}) (Any, error) {
 
 	url, err := TypeURL(v)
 	if err != nil {
-		return any{}, err
+		return nil, err
 	}
 
 	data, err := marshal(v)
 	if err != nil {
-		return any{}, err
+		return nil, err
 	}
-	return any{
+	return &any{
 		typeURL: url,
 		value:   data,
 	}, nil
@@ -175,6 +181,10 @@ func UnmarshalToByTypeURL(typeURL string, value []byte, out interface{}) error {
 }
 
 func unmarshal(typeURL string, value []byte, v interface{}) (interface{}, error) {
+	if value == nil {
+		return nil, nil
+	}
+
 	t, err := getTypeByUrl(typeURL)
 	if err != nil {
 		return nil, err

--- a/types_test.go
+++ b/types_test.go
@@ -191,3 +191,33 @@ func TestRegisterDiffUrls(t *testing.T) {
 	Register(&test{}, "test")
 	Register(&test{}, "test", "two")
 }
+
+func TestUnmarshalNil(t *testing.T) {
+	var pba *anypb.Any // This is nil.
+	var a Any = pba    // This is typed nil.
+
+	if pba != nil {
+		t.Fatal("pbany must be nil")
+	}
+	if a == nil {
+		t.Fatal("nilany must not be nil")
+	}
+
+	actual, err := UnmarshalAny(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual != nil {
+		t.Fatalf("expected nil, got %v", actual)
+	}
+}
+
+func TestCheckNil(t *testing.T) {
+	var a *any
+
+	actual := a.GetValue()
+	if actual != nil {
+		t.Fatalf("expected nil, got %v", actual)
+	}
+}


### PR DESCRIPTION
In Go, checking `a == nil` doesn't work when `a` is typed nil.
This commit changes the handling of nil inside typeurl.Any to make
`a.GetValue() == nil` the safer nil check alternative.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>