### PR TITLE
go.mod: module github.com/containerd/typeurl/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/containerd/typeurl
+module github.com/containerd/typeurl/v2
 
 go 1.13
 


### PR DESCRIPTION
Fix #39 

Let's release v2.1.0 after merging this (Or do we better release this as v3?)
