### PR TITLE
unmarshal does not return nil object when value is nil

### DIFF
--- a/types.go
+++ b/types.go
@@ -194,10 +194,6 @@ func UnmarshalToByTypeURL(typeURL string, value []byte, out interface{}) error {
 }
 
 func unmarshal(typeURL string, value []byte, v interface{}) (interface{}, error) {
-	if value == nil {
-		return nil, nil
-	}
-
 	t, err := getTypeByUrl(typeURL)
 	if err != nil {
 		return nil, err

--- a/types_test.go
+++ b/types_test.go
@@ -195,27 +195,6 @@ func TestRegisterDiffUrls(t *testing.T) {
 	Register(&test{}, "test", "two")
 }
 
-func TestUnmarshalNil(t *testing.T) {
-	var pba *anypb.Any // This is nil.
-	var a Any = pba    // This is typed nil.
-
-	if pba != nil {
-		t.Fatal("pbany must be nil")
-	}
-	if a == nil {
-		t.Fatal("nilany must not be nil")
-	}
-
-	actual, err := UnmarshalAny(a)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if actual != nil {
-		t.Fatalf("expected nil, got %v", actual)
-	}
-}
-
 func TestCheckNil(t *testing.T) {
 	var a *anyType
 


### PR DESCRIPTION
issue: https://github.com/containerd/containerd/issues/8392

For `unmarshal`, the`value param` is nil, it does not mean that typeurl is also empty.
When value is nil, the `unmarshal` returns `nil, nil` directly, which becomes cumbersome to use and skips the check for typeurl.

Always have unmarshal return a non-nil object when `err is nil`, which is consistent with the behavior of v1 typeurl