### PR TITLE
refactor marshalling funcs for anypb.Any

### DIFF
--- a/types.go
+++ b/types.go
@@ -27,6 +27,7 @@ import (
 	gogoproto "github.com/gogo/protobuf/proto"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 var (
@@ -194,6 +195,31 @@ func UnmarshalTo(any Any, out interface{}) error {
 func UnmarshalToByTypeURL(typeURL string, value []byte, out interface{}) error {
 	_, err := unmarshal(typeURL, value, out)
 	return err
+}
+
+// MarshalProto converts typeurl.Any to google.golang.org/protobuf/types/known/anypb.Any.
+func MarshalProto(from Any) *anypb.Any {
+	if from == nil {
+		return nil
+	}
+
+	if pbany, ok := from.(*anypb.Any); ok {
+		return pbany
+	}
+
+	return &anypb.Any{
+		TypeUrl: from.GetTypeUrl(),
+		Value:   from.GetValue(),
+	}
+}
+
+// MarshalAnyToProto converts an arbitrary interface to google.golang.org/protobuf/types/known/anypb.Any.
+func MarshalAnyToProto(from interface{}) (*anypb.Any, error) {
+	anyType, err := MarshalAny(from)
+	if err != nil {
+		return nil, err
+	}
+	return MarshalProto(anyType), nil
 }
 
 func unmarshal(typeURL string, value []byte, v interface{}) (interface{}, error) {

--- a/types_test.go
+++ b/types_test.go
@@ -167,6 +167,13 @@ func TestUnmarshalToInvalid(t *testing.T) {
 	}
 }
 
+func TestFromAny(t *testing.T) {
+	actual := MarshalProto(nil)
+	if actual != nil {
+		t.Fatalf("expected nil, got %v", actual)
+	}
+}
+
 func TestIs(t *testing.T) {
 	clear()
 	Register(&test{}, "test")


### PR DESCRIPTION
- move marshalling funcs for anypb.Any from containerd/containerd/protobuf to typeurl. This is more suited for the funcs since the funcs operate on `google.golang.org/protobuf/types/known/anypb.Any` and not on `github.com/containerd/containerd/pkg/protobuf/types.Any` which is again of type `anypb.Any`. Ref: https://github.com/containerd/containerd/blob/main/pkg/protobuf/types/types.go#L27