### PR TITLE
Update go version 1.21.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.17.x', '1.18.x']
+        go: ['1.21.x', '1.22.x']
 
     name: Typeurl CI
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         go: ['1.21.x', '1.22.x']
 
     name: Typeurl CI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/typeurl/v2
 
-go 1.13
+go 1.21
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
- update minimum go version to 1.21.x
- update CI to use ubuntu-24 runners