### PR TITLE
Make gogo optional at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ As a containerd sub-project, you will find the:
  * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
 
 information in our [`containerd/project`](https://github.com/containerd/project) repository.
+
+## Optional
+
+By default, support for gogoproto is available along side the standard Google
+protobuf types.
+You can choose to leave gogo support out by using the `!no_gogo` build tag.

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -33,6 +32,5 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/types_gogo.go
+++ b/types_gogo.go
@@ -1,0 +1,68 @@
+//go:build !no_gogo
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package typeurl
+
+import (
+	"reflect"
+
+	gogoproto "github.com/gogo/protobuf/proto"
+)
+
+func init() {
+	handlers = append(handlers, gogoHandler{})
+}
+
+type gogoHandler struct{}
+
+func (gogoHandler) Marshaller(v interface{}) func() ([]byte, error) {
+	pm, ok := v.(gogoproto.Message)
+	if !ok {
+		return nil
+	}
+	return func() ([]byte, error) {
+		return gogoproto.Marshal(pm)
+	}
+}
+
+func (gogoHandler) Unmarshaller(v interface{}) func([]byte) error {
+	pm, ok := v.(gogoproto.Message)
+	if !ok {
+		return nil
+	}
+
+	return func(dt []byte) error {
+		return gogoproto.Unmarshal(dt, pm)
+	}
+}
+
+func (gogoHandler) TypeURL(v interface{}) string {
+	pm, ok := v.(gogoproto.Message)
+	if !ok {
+		return ""
+	}
+	return gogoproto.MessageName(pm)
+}
+
+func (gogoHandler) GetType(url string) reflect.Type {
+	t := gogoproto.MessageType(url)
+	if t == nil {
+		return nil
+	}
+	return t.Elem()
+}

--- a/types_test.go
+++ b/types_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	gogotypes "github.com/gogo/protobuf/types"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -37,7 +36,6 @@ func clear() {
 	registry = make(map[reflect.Type]string)
 }
 
-var _ Any = &gogotypes.Any{}
 var _ Any = &anypb.Any{}
 
 func TestRegisterPointerGetPointer(t *testing.T) {


### PR DESCRIPTION
Since containerd is not using gogo anymore it seems like we should remove the depenency on gogo here since gogo is a fairly large dependency and is also unaintained.

This also gets imported by the runc shim and adds a fair amount to the binary size (in terms of percentage of the whole size).

I did keep a fallback test in that still imports gogo and continues to work. The test marshals a type with gogo and then unmarshals it by typeurl.
This is why gogo is still in the go.mod
Not sure if this is worthwhile or not.

This may need a module version bump since some functions will behave differently now.