### PR TITLE
Fix panic when type is not found

### DIFF
--- a/types.go
+++ b/types.go
@@ -284,16 +284,14 @@ func getTypeByUrl(url string) (reflect.Type, error) {
 	mu.RUnlock()
 	mt, err := protoregistry.GlobalTypes.FindMessageByURL(url)
 	if err != nil {
-		e := protoregistry.NotFound
-		if !errors.Is(err, e) {
-			return nil, fmt.Errorf("type with url %s: %w", url, ErrNotFound)
-		}
-
-		for _, h := range handlers {
-			if t := h.GetType(url); t != nil {
-				return t, nil
+		if errors.Is(err, protoregistry.NotFound) {
+			for _, h := range handlers {
+				if t := h.GetType(url); t != nil {
+					return t, nil
+				}
 			}
 		}
+		return nil, fmt.Errorf("type with url %s: %w", url, ErrNotFound)
 	}
 	empty := mt.New().Interface()
 	return reflect.TypeOf(empty).Elem(), nil

--- a/types_test.go
+++ b/types_test.go
@@ -18,6 +18,7 @@ package typeurl
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -228,5 +229,15 @@ func TestProtoFallback(t *testing.T) {
 	}
 	if expected.Sub(ts.AsTime()) != 0 {
 		t.Fatalf("expected %+v but got %+v", expected, ts.AsTime())
+	}
+}
+
+func TestUnmarshalNotFound(t *testing.T) {
+	_, err := UnmarshalByTypeURL("doesntexist", []byte("{}"))
+	if err == nil {
+		t.Fatalf("expected error unmarshalling type which does not exist")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("unexpected error unmarshalling type which does not exist: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes panic when type is not found and no handler is hit. The previous behavior without the handlers was to always return the not found error, that should be the default when the handlers do not return a result.