### PR TITLE
Fix unmarshalling of registered types

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -18,6 +18,7 @@ package typeurl
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -239,5 +240,26 @@ func TestUnmarshalNotFound(t *testing.T) {
 	}
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("unexpected error unmarshalling type which does not exist: %v", err)
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	url := t.Name()
+	Register(&timestamppb.Timestamp{}, url)
+
+	expected := timestamppb.Now()
+
+	dt, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var actual timestamppb.Timestamp
+	if err := UnmarshalToByTypeURL(url, dt, &actual); err != nil {
+		t.Fatal(err)
+	}
+
+	if !expected.AsTime().Equal(actual.AsTime()) {
+		t.Fatalf("expected value to be %q, got: %q", expected.AsTime(), actual.AsTime())
 	}
 }


### PR DESCRIPTION
In 7d3d25864aa9e808fd5bb1a151ef70978d4fa675 I inadvterantly removed support for json unmarshalling for the case when a type implements a protobuf message but is a type that is registered.

For types that are registered through the `Register` function typeurl is supposed to ignore the interfaces that the type implements and just use json.

This change restores that behavior.